### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://rebuy.visualstudio.com/31d26a36-eed5-4e5c-b85f-e1e192c1d2ba/169406fb-7d62-4313-af18-48bad2c22747/_apis/work/boardbadge/e1266801-7a90-4a9f-9c46-9f0f01a87eea)](https://rebuy.visualstudio.com/31d26a36-eed5-4e5c-b85f-e1e192c1d2ba/_boards/board/t/169406fb-7d62-4313-af18-48bad2c22747/Microsoft.EpicCategory)
 # Analysis Services
 Git repo for Analysis Services samples and community projects
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1691](https://rebuy.visualstudio.com/31d26a36-eed5-4e5c-b85f-e1e192c1d2ba/_workitems/edit/1691). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.